### PR TITLE
feat: add frontend checkout payments flow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -euo pipefail
+python scripts/update-system-guide.py
+if git diff --quiet -- SYSTEM_GUIDE.md; then
+  exit 0
+fi
+git add SYSTEM_GUIDE.md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Docs Guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Verify system guide is current
+        run: scripts/docs-check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env*
+.next/
+.DS_Store
+coverage/
+.vscode/
+.vercel/

--- a/Frontend/app/(checkout)/checkout/page.tsx
+++ b/Frontend/app/(checkout)/checkout/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import { PaymentProvider } from "@/features/payments/PaymentProvider";
+import { CheckoutStateProvider } from "@/features/payments/services/state";
+import { PaymentTelemetryProvider } from "@/features/payments/services/telemetry";
+import { CheckoutPage } from "@/features/payments/pages/CheckoutPage";
+
+const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+
+export default function CheckoutRoute() {
+  const searchParams = useSearchParams();
+  const auctionId = searchParams.get("auctionId");
+
+  const origin = useMemo(() => {
+    if (typeof window === "undefined") return "";
+    return window.location.origin;
+  }, []);
+
+  const successUrl = useMemo(() => {
+    if (!origin || !auctionId) return "";
+    return `${origin}/orders/${auctionId}?type=auction`;
+  }, [origin, auctionId]);
+
+  const cancelUrl = useMemo(() => {
+    if (!origin || !auctionId) return "";
+    return `${origin}/auction/${auctionId}?checkout=cancelled`;
+  }, [origin, auctionId]);
+
+  if (!publishableKey) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 py-16">
+        <h1 className="text-2xl font-semibold text-foreground">Payments unavailable</h1>
+        <p className="text-sm text-muted-foreground">
+          The Stripe publishable key is not configured. Set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY in your environment.
+        </p>
+      </div>
+    );
+  }
+
+  if (!auctionId) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 py-16">
+        <h1 className="text-2xl font-semibold text-foreground">Missing auction</h1>
+        <p className="text-sm text-muted-foreground">Provide an auctionId query parameter to continue.</p>
+      </div>
+    );
+  }
+
+  return (
+    <PaymentTelemetryProvider>
+      <PaymentProvider publishableKey={publishableKey}>
+        <CheckoutStateProvider>
+          <main className="mx-auto max-w-5xl px-4 py-10">
+            <CheckoutPage auctionId={auctionId} successUrl={successUrl} cancelUrl={cancelUrl} />
+          </main>
+        </CheckoutStateProvider>
+      </PaymentProvider>
+    </PaymentTelemetryProvider>
+  );
+}

--- a/Frontend/app/(checkout)/orders/[id]/page.tsx
+++ b/Frontend/app/(checkout)/orders/[id]/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useMemo } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+import { PaymentProvider } from "@/features/payments/PaymentProvider";
+import { CheckoutStateProvider } from "@/features/payments/services/state";
+import { PaymentTelemetryProvider } from "@/features/payments/services/telemetry";
+import { OrderConfirmationPage } from "@/features/payments/pages/OrderConfirmationPage";
+
+const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+
+export default function OrderConfirmationRoute() {
+  const params = useParams<{ id: string }>();
+  const searchParams = useSearchParams();
+  const type = searchParams.get("type");
+  const sessionId = searchParams.get("session_id");
+
+  const referenceId = params?.id ?? "";
+  const paymentId = type === "auction" ? undefined : referenceId;
+  const auctionId = type === "auction" ? referenceId : undefined;
+
+  const computedPaymentId = useMemo(() => {
+    if (paymentId) return paymentId;
+    if (sessionId) return sessionId;
+    return undefined;
+  }, [paymentId, sessionId]);
+
+  if (!publishableKey) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 py-16">
+        <h1 className="text-2xl font-semibold text-foreground">Payments unavailable</h1>
+        <p className="text-sm text-muted-foreground">
+          The Stripe publishable key is not configured. Set NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY in your environment.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <PaymentTelemetryProvider>
+      <PaymentProvider publishableKey={publishableKey}>
+        <CheckoutStateProvider>
+          <main className="mx-auto max-w-4xl px-4 py-10">
+            <OrderConfirmationPage paymentId={computedPaymentId} auctionId={auctionId} />
+          </main>
+        </CheckoutStateProvider>
+      </PaymentProvider>
+    </PaymentTelemetryProvider>
+  );
+}

--- a/Frontend/components/auction/AuctionDetail.tsx
+++ b/Frontend/components/auction/AuctionDetail.tsx
@@ -266,7 +266,9 @@ export function BiddingSection({
           </h1>
           {auction?.winnerId == user.id && (
             <button
-              onClick={handlePlaceBid}
+              onClick={() =>
+                router.push(`/checkout?auctionId=${auction?.id}`)
+              }
               disabled={user?.id == auction?.sellerId}
               className="w-full bg-yellow-600 hover:bg-yellow-500 text-black font-semibold py-2 rounded-lg"
             >
@@ -393,7 +395,7 @@ export function EndedBiddingSection({
             </div>
 
             <button
-              onClick={handlePlaceBid}
+              onClick={() => router.push(`/checkout?auctionId=${auction?.id}`)}
               disabled={user?.id == auction?.sellerId}
               className="w-full bg-yellow-600 hover:bg-yellow-500 text-black font-semibold py-2 rounded-lg"
             >

--- a/Frontend/features/payments/PAYMENTS_PLAYBOOK.md
+++ b/Frontend/features/payments/PAYMENTS_PLAYBOOK.md
@@ -1,0 +1,60 @@
+# Payments Playbook
+
+## Sequence Overview
+```mermaid
+sequenceDiagram
+    participant U as Buyer
+    participant FE as Frontend
+    participant API as ASP.NET Core API
+    participant Stripe
+    U->>FE: Click "Pay Now"
+    FE->>Stripe: loadStripe publishable key
+    FE->>API: POST /api/Payment/checkout-session
+    API->>Stripe: Create Checkout Session
+    Stripe-->>API: Session URL + metadata
+    API-->>FE: Session URL response
+    FE->>Stripe: redirectToCheckout(sessionId)
+    Stripe-->>Buyer: Hosted checkout + 3DS
+    Stripe-->>API: Webhook events (checkout.session.completed)
+    API->>DB: Update Payment status
+    FE->>API: GET /api/Payment/auction/{id}
+    API-->>FE: Payment summary
+```
+
+## Provider Decision Matrix
+| Capability                | Stripe Checkout | Notes |
+|---------------------------|-----------------|-------|
+| Card payments             | ✅              | Hosted Checkout ensures PCI isolation. |
+| Save payment methods      | ⚠️ Planned      | Requires future setup with Customer portal. |
+| 3DS / SCA                 | ✅              | Handled transparently by hosted flow. |
+| Alternative methods       | ⚠️ Planned      | Stripe Checkout supports expansion when enabled. |
+| Refund management         | ✅ (backend)    | Initiated by sellers via backend dashboard. |
+
+## Error Taxonomy
+| Code         | Scenario                                      | UX copy |
+|--------------|-----------------------------------------------|---------|
+| auth         | Missing/expired JWT                           | "Please sign in again." |
+| forbidden    | User not allowed to pay                       | "You are not allowed to pay for this auction." |
+| conflict     | Duplicate payment attempt                     | "A payment attempt is already in progress." |
+| not-found    | Auction/payment lookup failed                 | "We could not locate the payment record." |
+| unsupported  | Adapter feature not available (e.g. refund)   | "Feature not supported yet." |
+| server       | Generic backend/Stripe error                  | "Unable to process payment right now." |
+
+## Testing Matrix
+| Layer         | Tooling                  | Coverage |
+|---------------|--------------------------|----------|
+| Adapter/API   | Vitest unit tests        | Session ID parsing, error mapping |
+| Hooks         | Vitest + RTL             | Adapter integration, telemetry emission |
+| Components    | RTL smoke tests          | Status banner rendering |
+| Manual        | Stripe test cards        | Success, 3DS challenge, decline flows |
+
+## Integration Checklist
+- [x] Stripe publishable key configured via `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`.
+- [x] `SuccessUrl` points to `/orders/[id]` with `type=auction` fallback.
+- [x] Cancel URL returns user to auction detail page with notification query.
+- [x] Payment telemetry events emitted for init, request, failure, updates.
+- [x] Documentation auto-refresh enforced through `scripts/update-system-guide.py`.
+
+## References
+- Tailwind components follow [Tailwind/07-styling-with-utility-classes.md](../../Tailwind/07-styling-with-utility-classes.md).
+- React state patterns follow [React/36-managing-state.md](../../React/36-managing-state.md).

--- a/Frontend/features/payments/PaymentProvider.tsx
+++ b/Frontend/features/payments/PaymentProvider.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { createStripeAdapter } from "@/features/payments/adapters/stripe";
+import type {
+  PaymentAdapter,
+  PaymentAdapterConfig,
+} from "@/features/payments/types";
+import { usePaymentTelemetry } from "@/features/payments/hooks/usePaymentTelemetry";
+
+const adapterFactories = {
+  stripe: createStripeAdapter,
+};
+
+type SupportedAdapter = keyof typeof adapterFactories;
+
+interface PaymentProviderState {
+  status: "idle" | "loading" | "ready" | "error";
+  error?: string;
+}
+
+interface PaymentProviderProps extends PaymentAdapterConfig {
+  provider?: SupportedAdapter;
+  children: ReactNode;
+}
+
+const PaymentAdapterContext = createContext<PaymentAdapter | null>(null);
+const PaymentAdapterStateContext = createContext<PaymentProviderState>({
+  status: "idle",
+});
+
+export function PaymentProvider({
+  provider = "stripe",
+  publishableKey,
+  locale,
+  children,
+}: PaymentProviderProps) {
+  const telemetry = usePaymentTelemetry();
+  const [state, setState] = useState<PaymentProviderState>({ status: "idle" });
+  const [adapter, setAdapter] = useState<PaymentAdapter | null>(null);
+
+  const factory = useMemo(() => adapterFactories[provider], [provider]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const instance = factory();
+
+    async function initialise() {
+      setState({ status: "loading" });
+      telemetry.emit("adapter.init", { provider });
+      try {
+        await instance.init({ publishableKey, locale });
+        if (!cancelled) {
+          setAdapter(instance);
+          setState({ status: "ready" });
+        }
+      } catch (error) {
+        console.error("Failed to initialise payment adapter", error);
+        if (!cancelled) {
+          setState({ status: "error", error: (error as Error).message });
+          telemetry.emit("payment.error", {
+            stage: "adapter.init",
+            provider,
+            message: (error as Error).message,
+          });
+        }
+      }
+    }
+
+    initialise();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [factory, publishableKey, locale, provider, telemetry]);
+
+  const contextValue = useMemo(() => adapter, [adapter]);
+
+  return (
+    <PaymentAdapterStateContext.Provider value={state}>
+      <PaymentAdapterContext.Provider value={contextValue}>
+        {children}
+      </PaymentAdapterContext.Provider>
+    </PaymentAdapterStateContext.Provider>
+  );
+}
+
+export function usePaymentAdapter(): PaymentAdapter {
+  const adapter = useContext(PaymentAdapterContext);
+  if (!adapter) {
+    throw new Error(
+      "Payment adapter not ready. Wrap the tree with <PaymentProvider>."
+    );
+  }
+  return adapter;
+}
+
+export function usePaymentAdapterState(): PaymentProviderState {
+  return useContext(PaymentAdapterStateContext);
+}
+
+// State management mirrors React patterns from React/36-managing-state.md.

--- a/Frontend/features/payments/__tests__/api.test.ts
+++ b/Frontend/features/payments/__tests__/api.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCheckoutSession } from "@/features/payments/api/client";
+import { PaymentError } from "@/features/payments/services/errors";
+
+vi.mock("@/lib/api", () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const { fetchWithAuth } = require("@/lib/api");
+
+describe("createCheckoutSession", () => {
+  it("extracts the session id from the checkout url", async () => {
+    fetchWithAuth.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ url: "https://checkout.stripe.com/c/pay/cs_test_123" }),
+    });
+
+    const result = await createCheckoutSession({
+      auctionId: "abc",
+      successUrl: "https://example.com/success",
+      cancelUrl: "https://example.com/cancel",
+      idempotencyKey: "key",
+    });
+
+    expect(result.sessionId).toBe("cs_test_123");
+  });
+
+  it("throws a mapped payment error on failure", async () => {
+    fetchWithAuth.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ message: "Not found" }),
+    });
+
+    await expect(
+      createCheckoutSession({
+        auctionId: "abc",
+        successUrl: "s",
+        cancelUrl: "c",
+        idempotencyKey: "key",
+      })
+    ).rejects.toBeInstanceOf(PaymentError);
+  });
+});

--- a/Frontend/features/payments/__tests__/components.test.tsx
+++ b/Frontend/features/payments/__tests__/components.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PaymentStatusBanner } from "@/features/payments/components/PaymentStatusBanner";
+
+describe("PaymentStatusBanner", () => {
+  it("renders the correct label for completed status", () => {
+    render(<PaymentStatusBanner status="completed" updatedAt="2024-01-01T00:00:00Z" />);
+    expect(screen.getByText(/Payment completed/)).toBeInTheDocument();
+  });
+});

--- a/Frontend/features/payments/__tests__/hooks.test.tsx
+++ b/Frontend/features/payments/__tests__/hooks.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PaymentProvider } from "@/features/payments/PaymentProvider";
+import { CheckoutStateProvider } from "@/features/payments/services/state";
+import { PaymentTelemetryProvider } from "@/features/payments/services/telemetry";
+import { useCheckoutSession } from "@/features/payments/hooks/useCheckoutSession";
+
+const createPaymentMock = vi.fn(async () => ({ sessionUrl: "https://example.com", sessionId: "cs_test" }));
+const telemetryMock = { emit: vi.fn() };
+
+vi.mock("@/features/payments/adapters/stripe", () => ({
+  createStripeAdapter: () => ({
+    id: "stripe",
+    init: vi.fn(async () => undefined),
+    createPayment: createPaymentMock,
+    confirmPayment: vi.fn(),
+    handle3DS: vi.fn(),
+    saveMethod: vi.fn(),
+    listMethods: vi.fn(async () => []),
+    detachMethod: vi.fn(),
+    refund: vi.fn(),
+  }),
+}));
+
+describe("useCheckoutSession", () => {
+  it("invokes the adapter and telemetry", async () => {
+    function TestComponent() {
+      const { startCheckout, loading, error } = useCheckoutSession();
+      return (
+        <div>
+          <button
+            onClick={() =>
+              startCheckout({
+                auctionId: "auction",
+                successUrl: "https://example.com/success",
+                cancelUrl: "https://example.com/cancel",
+                idempotencyKey: "key",
+              })
+            }
+            disabled={loading}
+          >
+            Checkout
+          </button>
+          {error ? <p role="alert">{error.message}</p> : null}
+        </div>
+      );
+    }
+
+    render(
+      <PaymentTelemetryProvider sink={telemetryMock}>
+        <PaymentProvider publishableKey="pk_test">
+          <CheckoutStateProvider>
+            <TestComponent />
+          </CheckoutStateProvider>
+        </PaymentProvider>
+      </PaymentTelemetryProvider>
+    );
+
+    const button = await screen.findByText("Checkout");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(createPaymentMock).toHaveBeenCalled();
+    });
+
+    expect(telemetryMock.emit).toHaveBeenCalledWith("checkout.intent.requested", {
+      provider: "stripe",
+    });
+  });
+});

--- a/Frontend/features/payments/adapters/stripe.ts
+++ b/Frontend/features/payments/adapters/stripe.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { loadStripe, Stripe } from "@stripe/stripe-js";
+import type {
+  CheckoutIntentPayload,
+  CheckoutIntentResult,
+  PaymentAdapter,
+  PaymentAdapterConfig,
+  PaymentConfirmationResult,
+} from "@/features/payments/types";
+import {
+  PaymentError,
+  normalizeError,
+} from "@/features/payments/services/errors";
+import { createCheckoutSession } from "@/features/payments/api/client";
+
+function assertConfig(config: PaymentAdapterConfig | null): asserts config is PaymentAdapterConfig {
+  if (!config) {
+    throw new PaymentError("Stripe adapter not initialised", "config");
+  }
+}
+
+function extractStripeError(error: unknown): PaymentError {
+  const normalized = normalizeError(error);
+  if (normalized.code) return normalized;
+  return new PaymentError(normalized.message, "stripe", normalized);
+}
+
+async function redirectToCheckout(
+  stripe: Stripe,
+  result: CheckoutIntentResult
+): Promise<void> {
+  if (result.sessionId) {
+    const { error } = await stripe.redirectToCheckout({ sessionId: result.sessionId });
+    if (error) {
+      throw new PaymentError(error.message, error.type);
+    }
+  } else if (typeof window !== "undefined") {
+    window.location.assign(result.sessionUrl);
+  }
+}
+
+export function createStripeAdapter(): PaymentAdapter {
+  let stripePromise: Promise<Stripe | null> | null = null;
+  let config: PaymentAdapterConfig | null = null;
+
+  async function ensureStripe(): Promise<Stripe> {
+    assertConfig(config);
+    if (!stripePromise) {
+      stripePromise = loadStripe(config.publishableKey, {
+        locale: config.locale,
+      });
+    }
+    const stripe = await stripePromise;
+    if (!stripe) {
+      throw new PaymentError("Unable to initialise Stripe.js", "stripe-init");
+    }
+    return stripe;
+  }
+
+  return {
+    id: "stripe",
+    async init(nextConfig) {
+      config = nextConfig;
+      await ensureStripe();
+    },
+    async createPayment(payload: CheckoutIntentPayload): Promise<CheckoutIntentResult> {
+      try {
+        const session = await createCheckoutSession(payload);
+        const stripe = await ensureStripe();
+        await redirectToCheckout(stripe, session);
+        return session;
+      } catch (error) {
+        throw extractStripeError(error);
+      }
+    },
+    async confirmPayment(): Promise<PaymentConfirmationResult> {
+      throw new PaymentError(
+        "Direct confirmation is not supported for Stripe Checkout sessions.",
+        "unsupported"
+      );
+    },
+    async handle3DS(): Promise<PaymentConfirmationResult> {
+      throw new PaymentError(
+        "3DS challenges are handled inside the hosted Stripe Checkout flow.",
+        "unsupported"
+      );
+    },
+    async saveMethod() {
+      throw new PaymentError(
+        "Saving payment methods is not enabled for Stripe Checkout sessions.",
+        "unsupported"
+      );
+    },
+    async listMethods() {
+      return [];
+    },
+    async detachMethod() {
+      throw new PaymentError("Detaching methods is not available.", "unsupported");
+    },
+    async refund() {
+      throw new PaymentError(
+        "Refunds must be initiated from the seller dashboard in this release.",
+        "unsupported"
+      );
+    },
+  };
+}
+
+// Styling and UX expectations match Tailwind/07-styling-with-utility-classes.md guidance.

--- a/Frontend/features/payments/api/client.ts
+++ b/Frontend/features/payments/api/client.ts
@@ -1,0 +1,126 @@
+import { BASE_URL } from "@/config";
+import { fetchWithAuth } from "@/lib/api";
+import type {
+  CheckoutIntentPayload,
+  CheckoutIntentResult,
+  PaymentStatus,
+  PaymentSummary,
+} from "@/features/payments/types";
+import { mapApiError, PaymentError } from "@/features/payments/services/errors";
+
+function toPaymentSummary(data: any): PaymentSummary {
+  if (!data) {
+    throw new PaymentError("Payment response malformed", "invalid-response");
+  }
+  const status = String(data.status ?? "pending").toLowerCase() as PaymentStatus;
+  return {
+    id: String(data.id),
+    bidId: String(data.bidId),
+    totalAmount: Number(data.totalAmount ?? 0),
+    commission: Number(data.commission ?? 0),
+    currency: String(data.currency ?? "usd"),
+    status,
+    receiptUrl: data.receiptUrl ?? null,
+    paidAt: data.paidAt ?? null,
+    updatedAt: data.updatedAt ?? null,
+  };
+}
+
+function extractSessionIdFromUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const candidate = segments[segments.length - 1];
+    if (candidate?.startsWith("cs_")) {
+      return candidate;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function createCheckoutSession(
+  payload: CheckoutIntentPayload
+): Promise<CheckoutIntentResult> {
+  const response = await fetchWithAuth(`${BASE_URL}/api/Payment/checkout-session`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": payload.idempotencyKey,
+    },
+    body: JSON.stringify({
+      auctionId: payload.auctionId,
+      successUrl: payload.successUrl,
+      cancelUrl: payload.cancelUrl,
+      billingAddress: payload.billingAddress,
+    }),
+  });
+
+  if (!response.ok) {
+    let body: unknown = undefined;
+    try {
+      body = await response.json();
+    } catch {
+      body = await response.text();
+    }
+    throw mapApiError(response, body);
+  }
+
+  const data = await response.json();
+  const url = String(data.url);
+  return {
+    sessionUrl: url,
+    sessionId: extractSessionIdFromUrl(url),
+    paymentId: data.paymentId ?? undefined,
+  };
+}
+
+export async function fetchPaymentByBid(bidId: string): Promise<PaymentSummary> {
+  const response = await fetchWithAuth(`${BASE_URL}/api/Payment/bid/${bidId}`);
+  if (!response.ok) {
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      body = await response.text();
+    }
+    throw mapApiError(response, body);
+  }
+  const data = await response.json();
+  return toPaymentSummary(data);
+}
+
+export async function fetchPaymentById(id: string): Promise<PaymentSummary> {
+  const response = await fetchWithAuth(`${BASE_URL}/api/Payment/${id}`);
+  if (!response.ok) {
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      body = await response.text();
+    }
+    throw mapApiError(response, body);
+  }
+  const data = await response.json();
+  return toPaymentSummary(data);
+}
+
+export async function fetchPaymentByAuction(
+  auctionId: string
+): Promise<PaymentSummary> {
+  const response = await fetchWithAuth(
+    `${BASE_URL}/api/Payment/auction/${auctionId}`
+  );
+  if (!response.ok) {
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      body = await response.text();
+    }
+    throw mapApiError(response, body);
+  }
+  const data = await response.json();
+  return toPaymentSummary(data);
+}

--- a/Frontend/features/payments/components/ApplyCoupon.tsx
+++ b/Frontend/features/payments/components/ApplyCoupon.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import Button from "@/components/ui/Button";
+
+interface ApplyCouponProps {
+  onApply: (code: string) => Promise<void> | void;
+  applying?: boolean;
+  error?: string | null;
+}
+
+export function ApplyCoupon({ onApply, applying = false, error }: ApplyCouponProps) {
+  const [code, setCode] = useState("");
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!code.trim()) return;
+    await onApply(code.trim());
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2" aria-label="Apply coupon">
+      <div className="flex gap-2">
+        <input
+          value={code}
+          onChange={(event) => setCode(event.target.value)}
+          placeholder="Coupon code"
+          className="flex-1 rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+        />
+        <Button type="submit" variant="primary" disabled={applying}>
+          {applying ? "Applying…" : "Apply"}
+        </Button>
+      </div>
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+    </form>
+  );
+}
+
+// Form layout references Tailwind/07-styling-with-utility-classes.md.

--- a/Frontend/features/payments/components/BillingAddressForm.tsx
+++ b/Frontend/features/payments/components/BillingAddressForm.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { ChangeEvent } from "react";
+import { useCheckoutDispatch, useCheckoutState } from "@/features/payments/services/state";
+
+const emptyAddress = {
+  name: "",
+  email: "",
+  phone: "",
+  line1: "",
+  line2: "",
+  city: "",
+  state: "",
+  postalCode: "",
+  country: "",
+};
+
+export function BillingAddressForm() {
+  const dispatch = useCheckoutDispatch();
+  const state = useCheckoutState();
+  const address = state.billingAddress ?? emptyAddress;
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    const { name, value } = event.target;
+    dispatch({ type: "setBilling", payload: { ...address, [name]: value } });
+  }
+
+  return (
+    <section aria-labelledby="billing-heading" className="space-y-4">
+      <h2 id="billing-heading" className="text-lg font-semibold text-foreground">
+        Billing details
+      </h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">Full name</span>
+          <input
+            name="name"
+            value={address.name}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            required
+            autoComplete="name"
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">Email</span>
+          <input
+            name="email"
+            type="email"
+            value={address.email}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            required
+            autoComplete="email"
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">Phone</span>
+          <input
+            name="phone"
+            value={address.phone ?? ""}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            autoComplete="tel"
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">Address line 1</span>
+          <input
+            name="line1"
+            value={address.line1 ?? ""}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            autoComplete="address-line1"
+            required
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">Address line 2</span>
+          <input
+            name="line2"
+            value={address.line2 ?? ""}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            autoComplete="address-line2"
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">City</span>
+          <input
+            name="city"
+            value={address.city ?? ""}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            autoComplete="address-level2"
+            required
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">State/Province</span>
+          <input
+            name="state"
+            value={address.state ?? ""}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            autoComplete="address-level1"
+          />
+        </label>
+        <label className="flex flex-col text-sm">
+          <span className="mb-1 font-medium text-foreground">Postal code</span>
+          <input
+            name="postalCode"
+            value={address.postalCode ?? ""}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            autoComplete="postal-code"
+            required
+          />
+        </label>
+        <label className="flex flex-col text-sm md:col-span-2">
+          <span className="mb-1 font-medium text-foreground">Country</span>
+          <input
+            name="country"
+            value={address.country ?? ""}
+            onChange={handleChange}
+            className="rounded-md border border-stone-200 px-3 py-2 shadow-sm focus:border-gold-middle focus:outline-none focus:ring-2 focus:ring-gold-middle"
+            autoComplete="country"
+            required
+          />
+        </label>
+      </div>
+    </section>
+  );
+}
+
+// Form controls styled per Tailwind/09-forms.md guidance.

--- a/Frontend/features/payments/components/CardElement.tsx
+++ b/Frontend/features/payments/components/CardElement.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ShieldCheck } from "lucide-react";
+
+export function CardElement() {
+  return (
+    <div className="rounded-lg border border-stone-200 bg-white px-4 py-5 shadow-sm">
+      <div className="flex items-start gap-3">
+        <ShieldCheck className="mt-1 h-5 w-5 text-gold-middle" aria-hidden="true" />
+        <div className="space-y-1 text-sm">
+          <p className="font-medium text-foreground">Card details collected securely</p>
+          <p className="text-muted-foreground">
+            We redirect you to Stripe Checkout to enter your card, following their hosted payment fields. No card
+            numbers touch our servers, satisfying PCI guidance.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Accessibility guidance follows React/28-accessibility.md.

--- a/Frontend/features/payments/components/CheckoutButton.tsx
+++ b/Frontend/features/payments/components/CheckoutButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+import { useCheckoutSession } from "@/features/payments/hooks/useCheckoutSession";
+import { useCheckoutState } from "@/features/payments/services/state";
+import { PaymentError } from "@/features/payments/services/errors";
+
+interface CheckoutButtonProps {
+  auctionId: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export function CheckoutButton({ auctionId, successUrl, cancelUrl }: CheckoutButtonProps) {
+  const { startCheckout, loading } = useCheckoutSession();
+  const { billingAddress } = useCheckoutState();
+  const [error, setError] = useState<PaymentError | null>(null);
+
+  async function handleClick() {
+    setError(null);
+    try {
+      await startCheckout({
+        auctionId,
+        successUrl,
+        cancelUrl,
+        idempotencyKey: crypto.randomUUID(),
+        billingAddress: billingAddress ?? undefined,
+      });
+    } catch (err) {
+      setError(err as PaymentError);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="primary"
+        disabled={loading}
+        onClick={handleClick}
+      >
+        {loading ? "Redirecting to Stripe…" : "Pay securely"}
+      </Button>
+      {error ? <p className="text-sm text-red-600">{error.message}</p> : null}
+    </div>
+  );
+}
+
+// Button uses interaction guidance from Tailwind/03-essentials.md.

--- a/Frontend/features/payments/components/OrderSummary.tsx
+++ b/Frontend/features/payments/components/OrderSummary.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCheckoutState } from "@/features/payments/services/state";
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(amount);
+}
+
+export function OrderSummary() {
+  const { summary } = useCheckoutState();
+  if (!summary) {
+    return (
+      <aside className="rounded-lg border border-stone-200 bg-white px-4 py-5 shadow-sm">
+        <p className="text-sm text-muted-foreground">Order details will appear once the auction data loads.</p>
+      </aside>
+    );
+  }
+
+  const baseAmount = summary.totalAmount - summary.commission;
+  const total = summary.totalAmount;
+
+  return (
+    <aside className="rounded-lg border border-stone-200 bg-white px-4 py-5 shadow-sm">
+      <h2 className="text-lg font-semibold text-foreground">Order summary</h2>
+      <dl className="mt-4 space-y-3 text-sm">
+        <div className="flex items-center justify-between">
+          <dt className="text-muted-foreground">Winning bid</dt>
+          <dd className="font-medium text-foreground">{formatCurrency(baseAmount, summary.currency)}</dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt className="text-muted-foreground">Platform commission</dt>
+          <dd className="font-medium text-foreground">{formatCurrency(summary.commission, summary.currency)}</dd>
+        </div>
+        <div className="flex items-center justify-between border-t border-dashed border-stone-200 pt-3 text-base">
+          <dt className="font-semibold text-foreground">Total due</dt>
+          <dd className="font-semibold text-foreground">{formatCurrency(total, summary.currency)}</dd>
+        </div>
+      </dl>
+    </aside>
+  );
+}
+
+// Summary layout inspired by Tailwind/05-layouts.md examples.

--- a/Frontend/features/payments/components/PaymentMethodSelector.tsx
+++ b/Frontend/features/payments/components/PaymentMethodSelector.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect } from "react";
+import { useCheckoutDispatch, useCheckoutState } from "@/features/payments/services/state";
+import { usePaymentMethods } from "@/features/payments/hooks/usePaymentMethods";
+import type { PaymentMethodSummary } from "@/features/payments/types";
+
+function MethodRow({
+  method,
+  selected,
+  onSelect,
+}: {
+  method: PaymentMethodSummary;
+  selected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <label
+      className={`flex items-center justify-between rounded-md border px-4 py-3 transition focus-within:ring-2 focus-within:ring-gold-middle ${
+        selected ? "border-gold-middle shadow-sm" : "border-stone-200"
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <input
+          type="radio"
+          name="payment-method"
+          value={method.id}
+          checked={selected}
+          onChange={() => onSelect(method.id)}
+          className="h-4 w-4 text-gold-middle"
+          aria-label={`${method.brand ?? method.type} ending in ${method.last4 ?? "????"}`}
+        />
+        <div className="flex flex-col text-sm">
+          <span className="font-medium text-foreground">
+            {method.brand ?? "Card"} •••• {method.last4 ?? "????"}
+          </span>
+          {method.expMonth && method.expYear ? (
+            <span className="text-muted-foreground">Expires {method.expMonth}/{method.expYear}</span>
+          ) : null}
+        </div>
+      </div>
+      {method.isDefault ? (
+        <span className="rounded-full bg-gold-middle/10 px-3 py-1 text-xs text-gold-middle">
+          Default
+        </span>
+      ) : null}
+    </label>
+  );
+}
+
+export function PaymentMethodSelector() {
+  const { methods, loading } = usePaymentMethods();
+  const dispatch = useCheckoutDispatch();
+  const state = useCheckoutState();
+
+  useEffect(() => {
+    dispatch({ type: "setMethods", payload: methods });
+  }, [methods, dispatch]);
+
+  return (
+    <section aria-labelledby="payment-method-heading" className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 id="payment-method-heading" className="text-lg font-semibold text-foreground">
+          Payment method
+        </h2>
+        {loading ? <span className="text-sm text-muted-foreground">Loading…</span> : null}
+      </div>
+
+      <div className="space-y-3">
+        {state.availableMethods.length > 0 ? (
+          state.availableMethods.map((method) => (
+            <MethodRow
+              key={method.id}
+              method={method}
+              selected={state.selectedMethodId === method.id}
+              onSelect={(id) => dispatch({ type: "selectMethod", payload: id })}
+            />
+          ))
+        ) : (
+          <p className="rounded-md border border-dashed border-gold-middle/50 bg-white px-4 py-3 text-sm text-muted-foreground">
+            You can add a new card safely on the Stripe checkout screen. Saved methods will appear here
+            once available.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// UI styling references Tailwind/07-styling-with-utility-classes.md.

--- a/Frontend/features/payments/components/PaymentStatusBanner.tsx
+++ b/Frontend/features/payments/components/PaymentStatusBanner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { PaymentStatus } from "@/features/payments/types";
+
+interface PaymentStatusBannerProps {
+  status: PaymentStatus;
+  updatedAt?: string | null;
+}
+
+const styles: Record<PaymentStatus, { label: string; className: string; description: string }> = {
+  pending: {
+    label: "Payment pending",
+    className: "border-amber-400 bg-amber-50 text-amber-800",
+    description: "We are preparing your payment. You can refresh in a moment.",
+  },
+  processing: {
+    label: "Processing",
+    className: "border-sky-400 bg-sky-50 text-sky-800",
+    description: "Stripe is confirming the payment. This usually takes a few seconds.",
+  },
+  completed: {
+    label: "Payment completed",
+    className: "border-emerald-500 bg-emerald-50 text-emerald-800",
+    description: "Funds have been captured successfully.",
+  },
+  failed: {
+    label: "Payment failed",
+    className: "border-red-500 bg-red-50 text-red-700",
+    description: "The payment was declined. Try another method or contact support.",
+  },
+  refunded: {
+    label: "Refunded",
+    className: "border-purple-500 bg-purple-50 text-purple-800",
+    description: "The payment was refunded to your card.",
+  },
+  disputed: {
+    label: "Disputed",
+    className: "border-orange-500 bg-orange-50 text-orange-800",
+    description: "The payment is under dispute. Our team will reach out with next steps.",
+  },
+};
+
+export function PaymentStatusBanner({ status, updatedAt }: PaymentStatusBannerProps) {
+  const config = styles[status] ?? styles.pending;
+  return (
+    <div
+      role="status"
+      className={`rounded-md border px-4 py-3 text-sm ${config.className}`}
+    >
+      <p className="font-semibold">{config.label}</p>
+      <p>{config.description}</p>
+      {updatedAt ? (
+        <p className="mt-1 text-xs opacity-80">Last updated {new Date(updatedAt).toLocaleString()}</p>
+      ) : null}
+    </div>
+  );
+}
+
+// Status messaging follows accessibility notes from React/28-accessibility.md.

--- a/Frontend/features/payments/components/ThreeDSModal.tsx
+++ b/Frontend/features/payments/components/ThreeDSModal.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { ReactNode } from "react";
+
+interface ThreeDSModalProps {
+  open: boolean;
+  title?: string;
+  description?: string;
+  footer?: ReactNode;
+}
+
+export function ThreeDSModal({ open, title, description, footer }: ThreeDSModalProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? "threeds-title" : undefined}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div className="max-w-md rounded-lg bg-white p-6 shadow-lg">
+        {title ? (
+          <h2 id="threeds-title" className="text-lg font-semibold text-foreground">
+            {title}
+          </h2>
+        ) : null}
+        {description ? (
+          <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+        ) : null}
+        {footer ? <div className="mt-4 flex justify-end gap-2">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+// Modal semantics follow React/28-accessibility.md recommendations.

--- a/Frontend/features/payments/hooks/useCheckoutSession.ts
+++ b/Frontend/features/payments/hooks/useCheckoutSession.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { usePaymentAdapter } from "@/features/payments/PaymentProvider";
+import { normalizeError, PaymentError } from "@/features/payments/services/errors";
+import type { CheckoutIntentPayload } from "@/features/payments/types";
+import { usePaymentTelemetry } from "@/features/payments/hooks/usePaymentTelemetry";
+
+export function useCheckoutSession() {
+  const adapter = usePaymentAdapter();
+  const telemetry = usePaymentTelemetry();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<PaymentError | null>(null);
+
+  const startCheckout = useCallback(
+    async (payload: CheckoutIntentPayload) => {
+      setLoading(true);
+      setError(null);
+      telemetry.emit("checkout.intent.requested", { provider: adapter.id });
+      try {
+        const result = await adapter.createPayment(payload);
+        telemetry.emit("checkout.redirect", {
+          provider: adapter.id,
+          sessionId: result.sessionId,
+        });
+        return result;
+      } catch (cause) {
+        const normalized = normalizeError(cause);
+        setError(normalized);
+        telemetry.emit("checkout.intent.failed", {
+          provider: adapter.id,
+          code: normalized.code,
+        });
+        throw normalized;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [adapter, telemetry]
+  );
+
+  return { startCheckout, loading, error };
+}
+
+// Hook API follows React/33-responding-to-events.md for event-driven flows.

--- a/Frontend/features/payments/hooks/usePaymentMethods.ts
+++ b/Frontend/features/payments/hooks/usePaymentMethods.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePaymentAdapter } from "@/features/payments/PaymentProvider";
+import type { PaymentMethodSummary } from "@/features/payments/types";
+
+export function usePaymentMethods() {
+  const adapter = usePaymentAdapter();
+  const [methods, setMethods] = useState<PaymentMethodSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      setLoading(true);
+      try {
+        const data = await adapter.listMethods();
+        if (active) {
+          setMethods(data);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      active = false;
+    };
+  }, [adapter]);
+
+  return { methods, loading };
+}

--- a/Frontend/features/payments/hooks/usePaymentTelemetry.ts
+++ b/Frontend/features/payments/hooks/usePaymentTelemetry.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useTelemetrySink } from "@/features/payments/services/telemetry";
+import type { PaymentTelemetryEvent } from "@/features/payments/types";
+
+export function usePaymentTelemetry() {
+  const sink = useTelemetrySink();
+  return {
+    emit(name: PaymentTelemetryEvent["name"], properties?: Record<string, unknown>) {
+      sink.emit(name, properties);
+    },
+  };
+}

--- a/Frontend/features/payments/pages/CheckoutPage.tsx
+++ b/Frontend/features/payments/pages/CheckoutPage.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchPaymentByAuction } from "@/features/payments/api/client";
+import { PaymentStatusBanner } from "@/features/payments/components/PaymentStatusBanner";
+import { PaymentMethodSelector } from "@/features/payments/components/PaymentMethodSelector";
+import { BillingAddressForm } from "@/features/payments/components/BillingAddressForm";
+import { CardElement } from "@/features/payments/components/CardElement";
+import { OrderSummary } from "@/features/payments/components/OrderSummary";
+import { CheckoutButton } from "@/features/payments/components/CheckoutButton";
+import { ApplyCoupon } from "@/features/payments/components/ApplyCoupon";
+import { useCheckoutDispatch, useCheckoutState } from "@/features/payments/services/state";
+import { normalizeError, PaymentError } from "@/features/payments/services/errors";
+import { usePaymentTelemetry } from "@/features/payments/hooks/usePaymentTelemetry";
+
+interface CheckoutPageProps {
+  auctionId: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export function CheckoutPage({ auctionId, successUrl, cancelUrl }: CheckoutPageProps) {
+  const dispatch = useCheckoutDispatch();
+  const telemetry = usePaymentTelemetry();
+  const { summary } = useCheckoutState();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<PaymentError | null>(null);
+  const [couponError, setCouponError] = useState<string | null>(null);
+  const [couponLoading, setCouponLoading] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      telemetry.emit("payment.status.poll", { auctionId });
+      try {
+        const details = await fetchPaymentByAuction(auctionId);
+        if (!active) return;
+        dispatch({ type: "setSummary", payload: details });
+        telemetry.emit("payment.status.updated", { auctionId, status: details.status });
+      } catch (cause) {
+        if (!active) return;
+        const normalized = normalizeError(cause);
+        setError(normalized);
+        telemetry.emit("payment.error", {
+          stage: "summary.load",
+          message: normalized.message,
+        });
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      active = false;
+    };
+  }, [auctionId, dispatch, telemetry]);
+
+  async function handleApplyCoupon(code: string) {
+    setCouponLoading(true);
+    setCouponError(null);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      setCouponError("Coupons are not yet supported for auction payments.");
+    } finally {
+      setCouponLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <div className="space-y-6">
+        {summary ? (
+          <PaymentStatusBanner status={summary.status} updatedAt={summary.updatedAt} />
+        ) : null}
+        {error ? (
+          <div className="rounded-md border border-red-400 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error.message}
+          </div>
+        ) : null}
+        {loading ? <p className="text-sm text-muted-foreground">Loading checkout details…</p> : null}
+
+        <PaymentMethodSelector />
+        <CardElement />
+        <BillingAddressForm />
+        <ApplyCoupon onApply={handleApplyCoupon} applying={couponLoading} error={couponError} />
+        <CheckoutButton auctionId={auctionId} successUrl={successUrl} cancelUrl={cancelUrl} />
+      </div>
+      <OrderSummary />
+    </div>
+  );
+}
+
+// Page layout respects guidance from Tailwind/05-layouts.md for responsive grids.

--- a/Frontend/features/payments/pages/OrderConfirmationPage.tsx
+++ b/Frontend/features/payments/pages/OrderConfirmationPage.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchPaymentByAuction, fetchPaymentById } from "@/features/payments/api/client";
+import { PaymentStatusBanner } from "@/features/payments/components/PaymentStatusBanner";
+import { OrderSummary } from "@/features/payments/components/OrderSummary";
+import { useCheckoutDispatch, useCheckoutState } from "@/features/payments/services/state";
+import { normalizeError, PaymentError } from "@/features/payments/services/errors";
+import { usePaymentTelemetry } from "@/features/payments/hooks/usePaymentTelemetry";
+
+interface OrderConfirmationPageProps {
+  paymentId?: string;
+  auctionId?: string;
+}
+
+export function OrderConfirmationPage({ paymentId, auctionId }: OrderConfirmationPageProps) {
+  const dispatch = useCheckoutDispatch();
+  const { summary } = useCheckoutState();
+  const telemetry = usePaymentTelemetry();
+  const [error, setError] = useState<PaymentError | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      setError(null);
+      setLoading(true);
+      const target = paymentId ?? auctionId;
+      telemetry.emit("payment.status.poll", { paymentId, auctionId });
+      try {
+        const details = paymentId
+          ? await fetchPaymentById(paymentId)
+          : await (async () => {
+              if (!auctionId) throw new PaymentError("Missing payment reference");
+              return fetchPaymentByAuction(auctionId);
+            })();
+        if (!active) return;
+        dispatch({ type: "setSummary", payload: details });
+        telemetry.emit("payment.status.updated", {
+          paymentId: details.id,
+          status: details.status,
+          reference: target,
+        });
+      } catch (cause) {
+        if (!active) return;
+        const normalized = normalizeError(cause);
+        setError(normalized);
+        telemetry.emit("payment.error", {
+          stage: "confirmation.load",
+          message: normalized.message,
+        });
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+    load();
+    const interval = setInterval(load, 5000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [dispatch, paymentId, telemetry]);
+
+  const reference = paymentId ?? auctionId ?? "";
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <h1 className="text-2xl font-semibold text-foreground">Payment confirmation</h1>
+        <p className="text-sm text-muted-foreground">
+          We keep this page updated automatically. If you close it, you can revisit from your orders list.
+        </p>
+        <p className="text-xs text-muted-foreground">Reference: {reference}</p>
+      </div>
+      {loading ? <p className="text-sm text-muted-foreground">Checking payment status…</p> : null}
+      {error ? (
+        <div className="rounded-md border border-red-400 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error.message}
+        </div>
+      ) : null}
+      {summary ? (
+        <div className="space-y-4">
+          <PaymentStatusBanner status={summary.status} updatedAt={summary.updatedAt} />
+          {summary.receiptUrl ? (
+            <a
+              href={summary.receiptUrl}
+              className="inline-flex text-sm font-medium text-gold-middle underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              View Stripe receipt
+            </a>
+          ) : null}
+          <OrderSummary />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// Polling cadence informed by React/52-useeffect.md (cleaning intervals).

--- a/Frontend/features/payments/services/errors.ts
+++ b/Frontend/features/payments/services/errors.ts
@@ -1,0 +1,45 @@
+export class PaymentError extends Error {
+  constructor(message: string, public readonly code?: string, public readonly causeError?: unknown) {
+    super(message);
+    this.name = "PaymentError";
+  }
+}
+
+export function mapApiError(response: Response, body?: unknown): PaymentError {
+  const defaultMessage = "Unable to process payment at this time. Please try again.";
+  if (!response) return new PaymentError(defaultMessage);
+
+  if (response.status === 401) {
+    return new PaymentError("Authentication required. Please sign in again.", "auth");
+  }
+
+  if (response.status === 403) {
+    return new PaymentError("You are not allowed to pay for this auction.", "forbidden");
+  }
+
+  if (response.status === 404) {
+    return new PaymentError("We could not locate the payment record.", "not-found");
+  }
+
+  if (response.status === 409) {
+    return new PaymentError("A payment attempt is already in progress.", "conflict");
+  }
+
+  if (typeof body === "string" && body.trim().length) {
+    return new PaymentError(body.trim(), "server");
+  }
+
+  if (body && typeof body === "object" && "message" in (body as Record<string, unknown>)) {
+    return new PaymentError(String((body as Record<string, unknown>).message), "server");
+  }
+
+  return new PaymentError(defaultMessage, "server");
+}
+
+export function normalizeError(error: unknown): PaymentError {
+  if (error instanceof PaymentError) return error;
+  if (error instanceof Error) {
+    return new PaymentError(error.message, undefined, error);
+  }
+  return new PaymentError("Unexpected error", undefined, error);
+}

--- a/Frontend/features/payments/services/state.tsx
+++ b/Frontend/features/payments/services/state.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  Dispatch,
+  ReactNode,
+  createContext,
+  useContext,
+  useMemo,
+  useReducer,
+} from "react";
+import type {
+  BillingAddress,
+  PaymentMethodSummary,
+  PaymentSummary,
+} from "@/features/payments/types";
+
+interface CheckoutState {
+  selectedMethodId: string | null;
+  availableMethods: PaymentMethodSummary[];
+  billingAddress: BillingAddress | null;
+  summary: PaymentSummary | null;
+  couponCode: string | null;
+  lastUpdatedAt?: string;
+}
+
+type CheckoutAction =
+  | { type: "setMethods"; payload: PaymentMethodSummary[] }
+  | { type: "selectMethod"; payload: string | null }
+  | { type: "setBilling"; payload: BillingAddress | null }
+  | { type: "setSummary"; payload: PaymentSummary | null }
+  | { type: "setCoupon"; payload: string | null };
+
+const CheckoutStateContext = createContext<CheckoutState | undefined>(undefined);
+const CheckoutDispatchContext = createContext<Dispatch<CheckoutAction> | undefined>(
+  undefined
+);
+
+function reducer(state: CheckoutState, action: CheckoutAction): CheckoutState {
+  switch (action.type) {
+    case "setMethods":
+      return {
+        ...state,
+        availableMethods: action.payload,
+        selectedMethodId:
+          state.selectedMethodId && action.payload.some((m) => m.id === state.selectedMethodId)
+            ? state.selectedMethodId
+            : action.payload[0]?.id ?? null,
+      };
+    case "selectMethod":
+      return { ...state, selectedMethodId: action.payload };
+    case "setBilling":
+      return { ...state, billingAddress: action.payload };
+    case "setSummary":
+      return { ...state, summary: action.payload, lastUpdatedAt: new Date().toISOString() };
+    case "setCoupon":
+      return { ...state, couponCode: action.payload };
+    default:
+      return state;
+  }
+}
+
+const initialState: CheckoutState = {
+  selectedMethodId: null,
+  availableMethods: [],
+  billingAddress: null,
+  summary: null,
+  couponCode: null,
+};
+
+interface CheckoutProviderProps {
+  children: ReactNode;
+}
+
+export function CheckoutStateProvider({ children }: CheckoutProviderProps) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const dispatchMemo = useMemo(() => dispatch, [dispatch]);
+
+  return (
+    <CheckoutDispatchContext.Provider value={dispatchMemo}>
+      <CheckoutStateContext.Provider value={state}>
+        {children}
+      </CheckoutStateContext.Provider>
+    </CheckoutDispatchContext.Provider>
+  );
+}
+
+export function useCheckoutState(): CheckoutState {
+  const context = useContext(CheckoutStateContext);
+  if (!context) {
+    throw new Error(
+      "Checkout state not found. Wrap component tree with <CheckoutStateProvider>."
+    );
+  }
+  return context;
+}
+
+export function useCheckoutDispatch(): Dispatch<CheckoutAction> {
+  const dispatch = useContext(CheckoutDispatchContext);
+  if (!dispatch) {
+    throw new Error(
+      "Checkout dispatch not found. Wrap component tree with <CheckoutStateProvider>."
+    );
+  }
+  return dispatch;
+}
+
+export function useSelectedPaymentMethod(): PaymentMethodSummary | null {
+  const state = useCheckoutState();
+  return (
+    state.availableMethods.find((m) => m.id === state.selectedMethodId) ?? null
+  );
+}
+
+// Reducer-based state derived from React/36-managing-state.md guidance.

--- a/Frontend/features/payments/services/telemetry.tsx
+++ b/Frontend/features/payments/services/telemetry.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { ReactNode, createContext, useContext, useMemo } from "react";
+import type { PaymentTelemetryEvent } from "@/features/payments/types";
+
+type TelemetrySink = {
+  emit: (name: PaymentTelemetryEvent["name"], properties?: Record<string, unknown>) => void;
+};
+
+const noopSink: TelemetrySink = {
+  emit: () => {
+    // intentionally empty
+  },
+};
+
+const PaymentTelemetryContext = createContext<TelemetrySink>(noopSink);
+
+interface PaymentTelemetryProviderProps {
+  children: ReactNode;
+  sink?: TelemetrySink;
+}
+
+export function PaymentTelemetryProvider({
+  children,
+  sink,
+}: PaymentTelemetryProviderProps) {
+  const value = useMemo(() => {
+    if (sink) return sink;
+    return {
+      emit: (name: PaymentTelemetryEvent["name"], properties?: Record<string, unknown>) => {
+        if (process.env.NODE_ENV !== "production") {
+          console.debug("[payments.telemetry]", name, properties);
+        }
+      },
+    } satisfies TelemetrySink;
+  }, [sink]);
+
+  return (
+    <PaymentTelemetryContext.Provider value={value}>
+      {children}
+    </PaymentTelemetryContext.Provider>
+  );
+}
+
+export function useTelemetrySink(): TelemetrySink {
+  return useContext(PaymentTelemetryContext);
+}

--- a/Frontend/features/payments/types/index.ts
+++ b/Frontend/features/payments/types/index.ts
@@ -1,0 +1,91 @@
+export type PaymentStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed"
+  | "refunded"
+  | "disputed";
+
+export interface PaymentSummary {
+  id: string;
+  bidId: string;
+  totalAmount: number;
+  commission: number;
+  currency: string;
+  status: PaymentStatus;
+  receiptUrl?: string | null;
+  paidAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface BillingAddress {
+  name: string;
+  email: string;
+  phone?: string;
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+export interface CheckoutIntentPayload {
+  auctionId: string;
+  successUrl: string;
+  cancelUrl: string;
+  idempotencyKey: string;
+  billingAddress?: BillingAddress;
+}
+
+export interface CheckoutIntentResult {
+  sessionUrl: string;
+  sessionId?: string;
+  paymentId?: string;
+}
+
+export interface PaymentMethodSummary {
+  id: string;
+  type: "card" | "wallet" | "bank";
+  brand?: string;
+  last4?: string;
+  expMonth?: number;
+  expYear?: number;
+  isDefault?: boolean;
+}
+
+export interface PaymentAdapterConfig {
+  publishableKey: string;
+  locale?: string;
+}
+
+export interface PaymentConfirmationResult {
+  paymentId?: string;
+  status: PaymentStatus;
+  receiptUrl?: string | null;
+}
+
+export interface PaymentAdapter {
+  id: "stripe" | string;
+  init(config: PaymentAdapterConfig): Promise<void>;
+  createPayment(payload: CheckoutIntentPayload): Promise<CheckoutIntentResult>;
+  confirmPayment(clientSecret: string): Promise<PaymentConfirmationResult>;
+  handle3DS(clientSecret: string): Promise<PaymentConfirmationResult>;
+  saveMethod(): Promise<PaymentMethodSummary>;
+  listMethods(): Promise<PaymentMethodSummary[]>;
+  detachMethod(methodId: string): Promise<void>;
+  refund(paymentId: string, reason?: string): Promise<void>;
+}
+
+export interface PaymentTelemetryEvent {
+  name:
+    | "adapter.init"
+    | "checkout.intent.requested"
+    | "checkout.intent.ready"
+    | "checkout.intent.failed"
+    | "checkout.redirect"
+    | "payment.status.poll"
+    | "payment.status.updated"
+    | "payment.error";
+  properties?: Record<string, unknown>;
+}

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -6,11 +6,16 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@microsoft/signalr": "^9.0.6",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@stripe/react-stripe-js": "^2.8.0",
+    "@stripe/stripe-js": "^4.10.0",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
@@ -36,6 +41,10 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.4.8",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jsdom": "^21.1.7",
     "@types/classnames": "^2.3.0",
     "@types/lodash": "^4.17.20",
     "@types/node": "^20",
@@ -43,8 +52,11 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
+    "jsdom": "^24.0.0",
+    "msw": "^2.4.11",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.6",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.0"
   }
 }

--- a/Frontend/tests/setup.ts
+++ b/Frontend/tests/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/Frontend/vitest.config.ts
+++ b/Frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: [resolve(rootDir, "tests/setup.ts")],
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      "@": resolve(rootDir, "."),
+    },
+  },
+});

--- a/SYSTEM_GUIDE.md
+++ b/SYSTEM_GUIDE.md
@@ -1,0 +1,103 @@
+# System Guide
+
+## Overview & Stack
+- Frontend: Next.js 15.3.5 (App Router) with React ^19.0.0 and Tailwind CSS v4 via `@tailwindcss/postcss`.
+- Backend: ASP.NET Core 8 Web API with Entity Framework Core and Stripe.NET integration.
+- Tooling: TypeScript ^5, ESLint flat config, no default testing harness (payments introduces Vitest).
+- Deployment: Docker compose templates available in `Backend/docker-compose.yml`.
+
+## Frontend Architecture
+**Routing**
+- /(checkout)/checkout
+- /(checkout)/orders/[id]
+- /.
+- /Profile/[id]
+- /about
+- /auction/[id]
+- /categories/[categoryname]
+- /forgotpassword
+- /login
+- /myShop
+- /myShop/auctions
+- /myShop/myProducts
+- /myShop/notifications
+- /signup
+- /test
+
+**State & Context**
+- AuthContext
+- NotificationContext
+- ShopContext
+- WebSocketContext
+
+**Design Tokens (from `app/globals.css` — see `Tailwind`)**
+- gold-start = #c69320
+- gold-middle = #fcc201
+- gold-end = #dba514
+- radius = 0.625rem
+- background = #f9f9f9
+- foreground = #1e1e1e
+- off-white = #fe33f4
+- card = oklch(1 0 0)
+- card-foreground = oklch(0.145 0 0)
+- popover = oklch(1 0 0)
+
+## Backend Architecture
+**Controllers**
+- HttpPost checkout-session
+- HttpGet {id:guid}
+- HttpGet bid/{bidId:guid}
+- HttpGet auction/{auctionId:guid}
+- HttpGet user/{userId:guid}
+- HttpGet recent
+
+**Services (`StripePaymentService` methods)**
+- CreateCheckoutSessionForWinningBidAsync
+- CreateRefundAsync
+- FetchStripePaymentDetailsAsync
+- TryHandleWebhookLiteAsync
+
+## Payments Domain
+```mermaid
+sequenceDiagram
+    participant U as Buyer
+    participant FE as Frontend
+    participant BE as ASP.NET Core API
+    participant ST as Stripe
+    U->>FE: Initiate checkout
+    FE->>BE: POST /api/payment/checkout-session
+    BE->>ST: Create Stripe Checkout Session
+    ST-->>BE: Session URL
+    BE-->>FE: Redirect URL
+    U->>ST: Complete payment + 3DS
+    ST-->>BE: Webhook (checkout.session.completed)
+    BE->>BE: Update payment status + notify services
+    FE->>BE: GET payment status (polling)
+```
+
+State machine highlights: `Pending → Processing → Completed` with failure branches (`Failed`, `Refunded`, `Disputed`). Webhooks provide idempotent updates recorded in `WebhookEventLogs`.
+
+## Security & Compliance
+- PCI boundary: only Stripe Elements handles card data; backend stores Stripe IDs and metadata (no PAN).
+- JWT auth protects payment APIs; rate limiting configured via `AspNetCoreRateLimit`.
+- Webhook signatures validated with Stripe secret and configured tolerance.
+- Avoid logging PII; use structured logs via ASP.NET Core `ILogger`.
+
+## Test Strategy
+- Unit: Adapter logic and utilities covered by Vitest with SDK mocks.
+- Component: React Testing Library for forms, modals, and stateful flows.
+- Integration: MSW interceptors emulate backend payment endpoints.
+- Backend: Stripe webhook handlers exercised via application service tests (future work).
+
+## Ops & Observability
+- Observability: ASP.NET Core logging + Hangfire dashboard for jobs.
+- Telemetry: Frontend emits analytics events via payment telemetry service (non-PII).
+- Local reproduction: run backend via `dotnet run` and frontend via `npm run dev` in `Frontend/`.
+
+## Conventions
+- Coding style: TypeScript strict mode, React functional components, Tailwind utility classes.
+- Commits: Conventional Commits (e.g., `feat:`, `docs:`).
+- PRs: Provide summary, test plan, security notes, and doc references per payments playbook.
+
+## Changelog
+- 8cda19b - auto-update at 2025-09-27T11:34:04Z

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bidzy-monorepo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "docs:update": "python scripts/update-system-guide.py",
+    "docs:check": "python scripts/update-system-guide.py --check"
+  }
+}

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -euo pipefail
+python "$(dirname "$0")/update-system-guide.py" --check

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -euo pipefail
+git config core.hooksPath .githooks

--- a/scripts/update-system-guide.py
+++ b/scripts/update-system-guide.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Auto-generates the SYSTEM_GUIDE.md file from repo state."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+FRONTEND = ROOT / "Frontend"
+BACKEND = ROOT / "Backend"
+GUIDE_PATH = ROOT / "SYSTEM_GUIDE.md"
+TAILWIND_DOC = ROOT / "Tailwind"
+REACT_DOC = ROOT / "React"
+
+
+def read_json(path: Path) -> Dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def collect_next_info() -> Dict[str, str]:
+    package = read_json(FRONTEND / "package.json")
+    deps = package.get("dependencies", {})
+    dev_deps = package.get("devDependencies", {})
+    return {
+        "next": deps.get("next", "unknown"),
+        "react": deps.get("react", "unknown"),
+        "typescript": dev_deps.get("typescript", "unknown"),
+    }
+
+
+def list_app_routes() -> List[str]:
+    routes = []
+    app_dir = FRONTEND / "app"
+    if not app_dir.exists():
+        return routes
+    for path in app_dir.rglob("page.tsx"):
+        rel = path.relative_to(app_dir)
+        routes.append("/" + str(rel.parent).replace(os.sep, "/"))
+    return sorted(routes)
+
+
+def read_tailwind_tokens() -> List[str]:
+    tokens: List[str] = []
+    css_path = FRONTEND / "app" / "globals.css"
+    if not css_path.exists():
+        return tokens
+    token_regex = re.compile(r"--([\w-]+):\s*([^;]+);")
+    for line in css_path.read_text(encoding="utf-8").splitlines():
+        match = token_regex.search(line.strip())
+        if match:
+            tokens.append(f"{match.group(1)} = {match.group(2).strip()}")
+    return tokens
+
+
+def parse_payment_endpoints() -> List[str]:
+    controller = BACKEND / "Bidzy" / "API" / "Controllers" / "PaymentController.cs"
+    if not controller.exists():
+        return []
+    text = controller.read_text(encoding="utf-8")
+    pattern = re.compile(r"\[(Http[a-zA-Z]+)(?:\(\"([^\"]*)\"\))?\]")
+    endpoints = []
+    for method, route in pattern.findall(text):
+        route_display = route or "/"
+        endpoints.append(f"{method} {route_display}")
+    return endpoints
+
+
+def parse_payment_services() -> List[str]:
+    service = BACKEND / "Bidzy" / "Application" / "Services" / "Payments" / "StripePaymentService.cs"
+    if not service.exists():
+        return []
+    pattern = re.compile(r"Task<[^>]+>\s+(\w+Async)")
+    methods = sorted(set(pattern.findall(service.read_text(encoding="utf-8"))))
+    return methods
+
+
+def detect_auth_contexts() -> List[str]:
+    contexts_dir = FRONTEND / "contexts"
+    contexts = []
+    if not contexts_dir.exists():
+        return contexts
+    for file in contexts_dir.glob("*Context.tsx"):
+        contexts.append(file.name.replace(".tsx", ""))
+    return sorted(contexts)
+
+
+def run_git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=ROOT).decode().strip()
+
+
+def current_git_identifier() -> str:
+    try:
+        return run_git("rev-parse", "--short", "HEAD")
+    except subprocess.CalledProcessError:
+        return "0000000"
+
+
+def build_overview(info: Dict[str, str]) -> str:
+    return dedent(
+        f"""
+        - Frontend: Next.js {info['next']} (App Router) with React {info['react']} and Tailwind CSS v4 via `@tailwindcss/postcss`.
+        - Backend: ASP.NET Core 8 Web API with Entity Framework Core and Stripe.NET integration.
+        - Tooling: TypeScript {info['typescript']}, ESLint flat config, no default testing harness (payments introduces Vitest).
+        - Deployment: Docker compose templates available in `Backend/docker-compose.yml`.
+        """
+    ).strip()
+
+
+def build_frontend_architecture(routes: List[str], tokens: List[str], contexts: List[str]) -> str:
+    lines: List[str] = ["**Routing**"]
+    if routes:
+        lines.extend(f"- {route}" for route in routes)
+    else:
+        lines.append("- (none detected)")
+
+    lines.append("")
+    lines.append("**State & Context**")
+    if contexts:
+        lines.extend(f"- {name}" for name in contexts)
+    else:
+        lines.append("- (none)")
+
+    lines.append("")
+    lines.append(
+        f"**Design Tokens (from `app/globals.css` — see `{TAILWIND_DOC.relative_to(ROOT)}`)**"
+    )
+    if tokens:
+        lines.extend(f"- {token}" for token in tokens[:10])
+    else:
+        lines.append("- (not detected)")
+
+    return "\n".join(lines).strip()
+
+
+def build_backend_architecture(endpoints: List[str], services: List[str]) -> str:
+    lines: List[str] = ["**Controllers**"]
+    if endpoints:
+        lines.extend(f"- {line}" for line in endpoints)
+    else:
+        lines.append("- (none)")
+
+    lines.append("")
+    lines.append("**Services (`StripePaymentService` methods)**")
+    if services:
+        lines.extend(f"- {name}" for name in services)
+    else:
+        lines.append("- (none)")
+
+    return "\n".join(lines).strip()
+
+
+def build_payments_domain() -> str:
+    return dedent(
+        """
+        ```mermaid
+        sequenceDiagram
+            participant U as Buyer
+            participant FE as Frontend
+            participant BE as ASP.NET Core API
+            participant ST as Stripe
+            U->>FE: Initiate checkout
+            FE->>BE: POST /api/payment/checkout-session
+            BE->>ST: Create Stripe Checkout Session
+            ST-->>BE: Session URL
+            BE-->>FE: Redirect URL
+            U->>ST: Complete payment + 3DS
+            ST-->>BE: Webhook (checkout.session.completed)
+            BE->>BE: Update payment status + notify services
+            FE->>BE: GET payment status (polling)
+        ```
+
+        State machine highlights: `Pending → Processing → Completed` with failure branches (`Failed`, `Refunded`, `Disputed`). Webhooks provide idempotent updates recorded in `WebhookEventLogs`.
+        """
+    ).strip()
+
+
+def build_security() -> str:
+    return dedent(
+        """
+        - PCI boundary: only Stripe Elements handles card data; backend stores Stripe IDs and metadata (no PAN).
+        - JWT auth protects payment APIs; rate limiting configured via `AspNetCoreRateLimit`.
+        - Webhook signatures validated with Stripe secret and configured tolerance.
+        - Avoid logging PII; use structured logs via ASP.NET Core `ILogger`.
+        """
+    ).strip()
+
+
+def build_test_strategy() -> str:
+    return dedent(
+        """
+        - Unit: Adapter logic and utilities covered by Vitest with SDK mocks.
+        - Component: React Testing Library for forms, modals, and stateful flows.
+        - Integration: MSW interceptors emulate backend payment endpoints.
+        - Backend: Stripe webhook handlers exercised via application service tests (future work).
+        """
+    ).strip()
+
+
+def build_ops() -> str:
+    return dedent(
+        """
+        - Observability: ASP.NET Core logging + Hangfire dashboard for jobs.
+        - Telemetry: Frontend emits analytics events via payment telemetry service (non-PII).
+        - Local reproduction: run backend via `dotnet run` and frontend via `npm run dev` in `Frontend/`.
+        """
+    ).strip()
+
+
+def build_conventions() -> str:
+    return dedent(
+        """
+        - Coding style: TypeScript strict mode, React functional components, Tailwind utility classes.
+        - Commits: Conventional Commits (e.g., `feat:`, `docs:`).
+        - PRs: Provide summary, test plan, security notes, and doc references per payments playbook.
+        """
+    ).strip()
+
+
+def load_existing_changelog() -> List[str]:
+    if not GUIDE_PATH.exists():
+        return []
+    text = GUIDE_PATH.read_text(encoding="utf-8")
+    if "## Changelog" not in text:
+        return []
+    return text.split("## Changelog", maxsplit=1)[1].strip().splitlines()
+
+
+def build_changelog(existing: List[str], *, update: bool) -> str:
+    identifier = current_git_identifier()
+    timestamp = (
+        dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    entry = f"- {identifier} - auto-update at {timestamp}"
+    lines = [line for line in existing if line.strip()]
+    if update:
+        lines = [line for line in lines if not line.startswith(f"- {identifier} ")]
+        lines.insert(0, entry)
+    return "\n".join(lines)
+
+
+def render_guide(sections: Dict[str, str], changelog: str) -> str:
+    parts = [
+        "# System Guide",
+        "",
+        "## Overview & Stack",
+        sections["overview"],
+        "",
+        "## Frontend Architecture",
+        sections["frontend"],
+        "",
+        "## Backend Architecture",
+        sections["backend"],
+        "",
+        "## Payments Domain",
+        sections["payments"],
+        "",
+        "## Security & Compliance",
+        sections["security"],
+        "",
+        "## Test Strategy",
+        sections["tests"],
+        "",
+        "## Ops & Observability",
+        sections["ops"],
+        "",
+        "## Conventions",
+        sections["conventions"],
+        "",
+        "## Changelog",
+        changelog,
+    ]
+    return "\n".join(parts).strip() + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update SYSTEM_GUIDE.md")
+    parser.add_argument("--check", action="store_true", help="Fail if guide is out-of-date")
+    args = parser.parse_args()
+
+    info = collect_next_info()
+    routes = list_app_routes()
+    tokens = read_tailwind_tokens()
+    contexts = detect_auth_contexts()
+    endpoints = parse_payment_endpoints()
+    services = parse_payment_services()
+
+    sections = {
+        "overview": build_overview(info),
+        "frontend": build_frontend_architecture(routes, tokens, contexts),
+        "backend": build_backend_architecture(endpoints, services),
+        "payments": build_payments_domain(),
+        "security": build_security(),
+        "tests": build_test_strategy(),
+        "ops": build_ops(),
+        "conventions": build_conventions(),
+    }
+    changelog = build_changelog(load_existing_changelog(), update=not args.check)
+    rendered = render_guide(sections, changelog)
+
+    if args.check:
+        existing = GUIDE_PATH.read_text(encoding="utf-8") if GUIDE_PATH.exists() else ""
+        if existing != rendered:
+            print("SYSTEM_GUIDE.md is out of date. Run npm run docs:update.")
+            raise SystemExit(1)
+        print("SYSTEM_GUIDE.md is up to date.")
+        return
+
+    GUIDE_PATH.write_text(rendered, encoding="utf-8")
+    print("SYSTEM_GUIDE.md updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce a Stripe-backed payment provider layer with hooks, API client, UI primitives, and a dedicated payments playbook for the frontend
- add checkout and order confirmation app routes wired to backend payment endpoints plus winner CTA updates in the auction experience
- automate SYSTEM_GUIDE.md maintenance with an update script, reusable hooks installer, and CI guard

## Testing
- ⚠️ `npm run test` *(blocked: npm registry returned 403 when installing new dev dependencies)*
- ✅ `python scripts/update-system-guide.py --check`


------
https://chatgpt.com/codex/tasks/task_e_68d7c462568c8324bbcbbd861f6753e5